### PR TITLE
Fix docs: install PyQt6 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 1.15.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==23.1.0]
+        additional_dependencies: [black==23.7.0]
 -   repo: https://github.com/asottile/reorder-python-imports
     rev: v3.10.0
     hooks:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 furo
+pyqt6
 sphinx
 sphinx-copybutton


### PR DESCRIPTION
We need some Qt API installed in order to be able to import the modules and generate the Reference API.